### PR TITLE
Added unit test for notificationService

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -9,13 +9,10 @@
     <option name="autoReloadType" value="NONE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="3fdad77f-c22d-44a4-813d-b11bd1679aca" name="Changes" comment="Modify admin capacity edit as to not override active reservations">
-      <change afterPath="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk/controller/AdminEventValidationTest.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk/integration/AdminEventIntegrationTest.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk/service/EventCapacityUpdateTest.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk/service/EventServiceTest.java" afterDir="false" />
+    <list default="true" id="3fdad77f-c22d-44a4-813d-b11bd1679aca" name="Changes" comment="Merge remote-tracking branch 'origin/dev' into feature/events&#10;# Please enter a commit message to explain why this merge is necessary,&#10;# especially if it merges an updated upstream into a topic branch.&#10;#&#10;# Lines starting with '#' will be ignored, and an empty message aborts&#10;# the commit.">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/app/build.gradle.kts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk/service/NotificationServiceTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk/service/NotificationServiceTest.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -25,7 +22,7 @@
   <component name="ClangdSettings">
     <option name="formatViaClangd" value="false" />
   </component>
-  <component name="ExecutionTargetManager" SELECTED_TARGET="device_and_snapshot_combo_box_target[LocalEmulator::path=/Users/elif/.android/avd/Medium_Phone.avd]" />
+  <component name="ExecutionTargetManager" SELECTED_TARGET="device_and_snapshot_combo_box_target[LocalEmulator::path=C:\Users\hibat_jze8h9z\.android\avd\Medium_Phone.avd]" />
   <component name="ExternalProjectsData">
     <projectState path="$PROJECT_DIR$">
       <ProjectState />
@@ -39,7 +36,12 @@
         </task>
         <projects_view>
           <tree_state>
-            <expand />
+            <expand>
+              <path>
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
+                <item name="CloudTicketReservationWK" type="f1a62948:ProjectNode" />
+              </path>
+            </expand>
             <select />
           </tree_state>
         </projects_view>
@@ -89,10 +91,8 @@
   <component name="PropertiesComponent"><![CDATA[{
   "keyToString": {
     "Android App.app.executor": "Run",
-    "Gradle.AdminEventValidationTest.executor": "Run",
-    "Gradle.AdminEventValidationTest.testEmptyTitleIsInvalid.executor": "Run",
-    "Gradle.AdminEventValidationTest.testValidCapacityValues.executor": "Run",
-    "Gradle.EventCapacityUpdateTest.executor": "Run",
+    "Gradle.EventListActivitySearchFilterTest.executor": "Run",
+    "Gradle.NotificationServiceTest.executor": "Run",
     "ModuleVcsDetector.initialDetectionPerformed": "true",
     "RunOnceActivity.MCP Project settings loaded": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
@@ -104,7 +104,7 @@
     "cf.first.check.clang-format": "false",
     "cidr.known.project.marker": "true",
     "com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultModelSelectionForGA.v1": "true",
-    "git-widget-placeholder": "bug/event-edit",
+    "git-widget-placeholder": "unitTest/notificationService",
     "ignore.virus.scanning.warn.message": "true",
     "junie.onboarding.icon.badge.shown": "true",
     "kotlin-language-version-configured": "true",
@@ -122,7 +122,7 @@
       <recent name="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk" />
     </key>
   </component>
-  <component name="RunManager" selected="Gradle.EventCapacityUpdateTest">
+  <component name="RunManager" selected="Gradle.NotificationServiceTest">
     <configuration name="app" type="AndroidRunConfigurationType" factoryName="Android App" activateToolWindowBeforeRun="false">
       <module name="CloudTicketReservationWK.app" />
       <option name="ANDROID_RUN_CONFIGURATION_SCHEMA_VERSION" value="1" />
@@ -195,7 +195,7 @@
         <option name="Android.Gradle.BeforeRunTask" enabled="true" />
       </method>
     </configuration>
-    <configuration name="AdminEventValidationTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="EventListActivitySearchFilterTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -208,7 +208,7 @@
           <list>
             <option value=":app:testDebugUnitTest" />
             <option value="--tests" />
-            <option value="&quot;com.example.cloudticketreservationwk.controller.AdminEventValidationTest&quot;" />
+            <option value="&quot;com.example.cloudticketreservationwk.controller.EventListActivitySearchFilterTest&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -219,7 +219,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="AdminEventValidationTest.testEmptyTitleIsInvalid" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="NotificationServiceTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -232,55 +232,7 @@
           <list>
             <option value=":app:testDebugUnitTest" />
             <option value="--tests" />
-            <option value="&quot;com.example.cloudticketreservationwk.controller.AdminEventValidationTest.testEmptyTitleIsInvalid&quot;" />
-          </list>
-        </option>
-        <option name="vmOptions" />
-      </ExternalSystemSettings>
-      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
-      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-      <DebugAllEnabled>false</DebugAllEnabled>
-      <RunAsTest>true</RunAsTest>
-      <method v="2" />
-    </configuration>
-    <configuration name="AdminEventValidationTest.testValidCapacityValues" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
-      <ExternalSystemSettings>
-        <option name="executionName" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="externalSystemIdString" value="GRADLE" />
-        <option name="scriptParameters" value="" />
-        <option name="taskDescriptions">
-          <list />
-        </option>
-        <option name="taskNames">
-          <list>
-            <option value=":app:testDebugUnitTest" />
-            <option value="--tests" />
-            <option value="&quot;com.example.cloudticketreservationwk.controller.AdminEventValidationTest.testValidCapacityValues&quot;" />
-          </list>
-        </option>
-        <option name="vmOptions" />
-      </ExternalSystemSettings>
-      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
-      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-      <DebugAllEnabled>false</DebugAllEnabled>
-      <RunAsTest>true</RunAsTest>
-      <method v="2" />
-    </configuration>
-    <configuration name="EventCapacityUpdateTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
-      <ExternalSystemSettings>
-        <option name="executionName" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="externalSystemIdString" value="GRADLE" />
-        <option name="scriptParameters" value="" />
-        <option name="taskDescriptions">
-          <list />
-        </option>
-        <option name="taskNames">
-          <list>
-            <option value=":app:testDebugUnitTest" />
-            <option value="--tests" />
-            <option value="&quot;com.example.cloudticketreservationwk.service.EventCapacityUpdateTest&quot;" />
+            <option value="&quot;com.example.cloudticketreservationwk.service.NotificationServiceTest&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -293,10 +245,8 @@
     </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="Gradle.EventCapacityUpdateTest" />
-        <item itemvalue="Gradle.AdminEventValidationTest.testValidCapacityValues" />
-        <item itemvalue="Gradle.AdminEventValidationTest.testEmptyTitleIsInvalid" />
-        <item itemvalue="Gradle.AdminEventValidationTest" />
+        <item itemvalue="Gradle.NotificationServiceTest" />
+        <item itemvalue="Gradle.EventListActivitySearchFilterTest" />
       </list>
     </recent_temporary>
   </component>
@@ -395,15 +345,7 @@
       <option name="project" value="LOCAL" />
       <updated>1773427306364</updated>
     </task>
-    <task id="LOCAL-00011" summary="Modify admin capacity edit as to not override active reservations">
-      <option name="closed" value="true" />
-      <created>1775339556655</created>
-      <option name="number" value="00011" />
-      <option name="presentableId" value="LOCAL-00011" />
-      <option name="project" value="LOCAL" />
-      <updated>1775339556655</updated>
-    </task>
-    <option name="localTasksCounter" value="12" />
+    <option name="localTasksCounter" value="11" />
     <servers />
   </component>
   <component name="VcsManagerConfiguration">
@@ -414,20 +356,19 @@
     <MESSAGE value="Modify to JUnit 4." />
     <MESSAGE value="Update example test file to JUnit 4." />
     <MESSAGE value="Commit" />
-    <MESSAGE value="Modify admin capacity edit as to not override active reservations" />
-    <option name="LAST_COMMIT_MESSAGE" value="Modify admin capacity edit as to not override active reservations" />
+    <option name="LAST_COMMIT_MESSAGE" value="Commit" />
   </component>
   <component name="play_dynamic_filters_status">
     <option name="appIdToCheckInfo">
       <map>
         <entry key="com.example.cloudticketreservationwk">
           <value>
-            <CheckInfo lastCheckTimestamp="1774740243753" />
+            <CheckInfo lastCheckTimestamp="1774542620691" />
           </value>
         </entry>
         <entry key="com.example.cloudticketreservationwk.test">
           <value>
-            <CheckInfo lastCheckTimestamp="1774740243751" />
+            <CheckInfo lastCheckTimestamp="1774542620692" />
           </value>
         </entry>
       </map>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -11,24 +11,7 @@
   <component name="ChangeListManager">
     <list default="true" id="3fdad77f-c22d-44a4-813d-b11bd1679aca" name="Changes" comment="Merge remote-tracking branch 'origin/dev' into feature/events&#10;# Please enter a commit message to explain why this merge is necessary,&#10;# especially if it merges an updated upstream into a topic branch.&#10;#&#10;# Lines starting with '#' will be ignored, and an empty message aborts&#10;# the commit.">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/functions/index.js" beforeDir="false" afterPath="$PROJECT_DIR$/functions/index.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/functions/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/functions/package-lock.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/functions/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/functions/package.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/node_modules/.package-lock.json" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/node_modules/dotenv/CHANGELOG.md" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/node_modules/dotenv/LICENSE" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/node_modules/dotenv/README-es.md" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/node_modules/dotenv/README.md" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/node_modules/dotenv/SECURITY.md" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/node_modules/dotenv/config.d.ts" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/node_modules/dotenv/config.js" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/node_modules/dotenv/lib/cli-options.js" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/node_modules/dotenv/lib/env-options.js" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/node_modules/dotenv/lib/main.d.ts" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/node_modules/dotenv/lib/main.js" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/node_modules/dotenv/package.json" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/package-lock.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/app/build.gradle.kts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -47,6 +30,9 @@
   <component name="ExternalProjectsManager">
     <system id="GRADLE">
       <state>
+        <task path="$PROJECT_DIR$">
+          <activation />
+        </task>
         <projects_view>
           <tree_state>
             <expand>
@@ -88,7 +74,7 @@
     &quot;accountId&quot;: &quot;d9082485-d84a-41e9-8978-834d7221064d&quot;
   }
 }</component>
-  <component name="GradleScriptDefinitionsStorage" workingDir="$PROJECT_DIR$" gradleHome="$USER_HOME$/.gradle/wrapper/dists/gradle-8.11.1-bin/bpt9gzteqjrbo1mjrsomdt32c/gradle-8.11.1" javaHome="$APPLICATION_HOME_DIR$/jbr/Contents/Home" gradleVersion="8.11.1" />
+  <component name="GradleScriptDefinitionsStorage" workingDir="$PROJECT_DIR$" gradleHome="C:\Users\hibat_jze8h9z\.gradle\wrapper\dists\gradle-8.11.1-bin\bpt9gzteqjrbo1mjrsomdt32c\gradle-8.11.1" javaHome="C:\Program Files\Android\Android Studio\jbr" gradleVersion="8.11.1" />
   <component name="McpProjectServerCommands">
     <commands />
     <urls />
@@ -104,6 +90,7 @@
   <component name="PropertiesComponent"><![CDATA[{
   "keyToString": {
     "Android App.app.executor": "Run",
+    "Gradle.NotificationServiceTest.executor": "Run",
     "ModuleVcsDetector.initialDetectionPerformed": "true",
     "RunOnceActivity.MCP Project settings loaded": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
@@ -115,7 +102,7 @@
     "cf.first.check.clang-format": "false",
     "cidr.known.project.marker": "true",
     "com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultModelSelectionForGA.v1": "true",
-    "git-widget-placeholder": "feature/notifications",
+    "git-widget-placeholder": "unitTest/notificationService",
     "ignore.virus.scanning.warn.message": "true",
     "junie.onboarding.icon.badge.shown": "true",
     "kotlin-language-version-configured": "true",
@@ -133,7 +120,7 @@
       <recent name="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk" />
     </key>
   </component>
-  <component name="RunManager">
+  <component name="RunManager" selected="Android App.app">
     <configuration name="app" type="AndroidRunConfigurationType" factoryName="Android App" activateToolWindowBeforeRun="false">
       <module name="CloudTicketReservationWK.app" />
       <option name="ANDROID_RUN_CONFIGURATION_SCHEMA_VERSION" value="1" />
@@ -206,6 +193,35 @@
         <option name="Android.Gradle.BeforeRunTask" enabled="true" />
       </method>
     </configuration>
+    <configuration name="NotificationServiceTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":app:testDebugUnitTest" />
+            <option value="--tests" />
+            <option value="&quot;com.example.cloudticketreservationwk.service.NotificationServiceTest&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
+    <recent_temporary>
+      <list>
+        <item itemvalue="Gradle.NotificationServiceTest" />
+      </list>
+    </recent_temporary>
   </component>
   <component name="SharedIndexes">
     <attachedChunks>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,7 +48,6 @@ dependencies {
     implementation(libs.constraintlayout)
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
-    testImplementation("org.mockito:mockito-core:5.12.0")
 
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.espresso.core)
@@ -60,13 +59,11 @@ dependencies {
     testImplementation("org.mockito:mockito-core:5.12.0")
     testImplementation("org.mockito:mockito-inline:5.2.0")
 
-}
-
-// DON'T REMOVE (for junit5)
-tasks.withType<Test> {
-    useJUnitPlatform()
     implementation(platform("com.google.firebase:firebase-bom:33.1.2"))
     implementation("com.google.firebase:firebase-auth")
     implementation("com.google.firebase:firebase-firestore")
+}
 
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,10 @@ dependencies {
     androidTestImplementation("androidx.test:runner:1.5.2")
     androidTestImplementation("androidx.test:core:1.5.0")
 
+    // Mockito
+    testImplementation("org.mockito:mockito-core:5.12.0")
+    testImplementation("org.mockito:mockito-inline:5.2.0")
+
 }
 
 // DON'T REMOVE (for junit5)

--- a/app/src/test/java/com/example/cloudticketreservationwk/service/NotificationServiceTest.java
+++ b/app/src/test/java/com/example/cloudticketreservationwk/service/NotificationServiceTest.java
@@ -1,0 +1,216 @@
+package com.example.cloudticketreservationwk.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import android.content.Context;
+
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.Query;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class NotificationServiceTest {
+
+    private Context mockContext;
+    private FirebaseFirestore mockFirestore;
+    private CollectionReference mockReservationsCollection;
+    private CollectionReference mockNotificationsCollection;
+    private Query mockQueryAfterEventId;
+    private Query mockQueryAfterStatus;
+    private Task<QuerySnapshot> mockTask;
+    private QuerySnapshot mockQuerySnapshot;
+    private DocumentSnapshot mockDoc1;
+    private DocumentSnapshot mockDoc2;
+    private DocumentReference mockDocRef1;
+    private DocumentReference mockDocRef2;
+    private DocumentReference mockNotificationDocRef;
+    private Task<DocumentReference> mockAddTask;
+
+    @BeforeEach
+    public void setUp() {
+        mockContext = mock(Context.class);
+        mockFirestore = mock(FirebaseFirestore.class);
+        mockReservationsCollection = mock(CollectionReference.class);
+        mockNotificationsCollection = mock(CollectionReference.class);
+        mockQueryAfterEventId = mock(Query.class);
+        mockQueryAfterStatus = mock(Query.class);
+        mockTask = mock(Task.class);
+        mockQuerySnapshot = mock(QuerySnapshot.class);
+        mockDoc1 = mock(DocumentSnapshot.class);
+        mockDoc2 = mock(DocumentSnapshot.class);
+        mockDocRef1 = mock(DocumentReference.class);
+        mockDocRef2 = mock(DocumentReference.class);
+        mockNotificationDocRef = mock(DocumentReference.class);
+        mockAddTask = mock(Task.class);
+    }
+
+    @Test
+    public void testNotifyEventCancellation_Success() {
+        try (MockedStatic<FirebaseFirestore> firestoreStatic = mockStatic(FirebaseFirestore.class)) {
+            firestoreStatic.when(FirebaseFirestore::getInstance).thenReturn(mockFirestore);
+
+            when(mockFirestore.collection("reservations")).thenReturn(mockReservationsCollection);
+            when(mockFirestore.collection("notifications")).thenReturn(mockNotificationsCollection);
+
+            when(mockReservationsCollection.whereEqualTo("eventId", "event123"))
+                    .thenReturn(mockQueryAfterEventId);
+
+            when(mockQueryAfterEventId.whereEqualTo("status", "Active"))
+                    .thenReturn(mockQueryAfterStatus);
+
+            when(mockQueryAfterStatus.get()).thenReturn(mockTask);
+
+            when(mockDoc1.getString("userId")).thenReturn("user1");
+            when(mockDoc1.getId()).thenReturn("res1");
+            when(mockDoc1.getReference()).thenReturn(mockDocRef1);
+
+            when(mockDoc2.getString("userId")).thenReturn("user2");
+            when(mockDoc2.getId()).thenReturn("res2");
+            when(mockDoc2.getReference()).thenReturn(mockDocRef2);
+
+            when(mockQuerySnapshot.getDocuments()).thenReturn(Arrays.asList(mockDoc1, mockDoc2));
+
+            when(mockNotificationsCollection.add(any())).thenReturn(mockAddTask);
+
+            when(mockTask.addOnSuccessListener(any())).thenAnswer(invocation -> {
+                OnSuccessListener<QuerySnapshot> listener = invocation.getArgument(0);
+                listener.onSuccess(mockQuerySnapshot);
+                return mockTask;
+            });
+
+            when(mockTask.addOnFailureListener(any())).thenReturn(mockTask);
+
+            NotificationService service = new NotificationService(mockContext);
+
+            TestCallback callback = new TestCallback();
+
+            service.notifyEventCancellation("event123", "Test Event", callback);
+
+            verify(mockFirestore).collection("reservations");
+            verify(mockReservationsCollection).whereEqualTo("eventId", "event123");
+            verify(mockQueryAfterEventId).whereEqualTo("status", "Active");
+            verify(mockQueryAfterStatus).get();
+
+            verify(mockNotificationsCollection, times(2)).add(any());
+            verify(mockDocRef1).update("status", "Cancelled");
+            verify(mockDocRef2).update("status", "Cancelled");
+
+            assertTrue(callback.successCalled);
+            assertFalse(callback.failureCalled);
+            assertEquals("Cancelled event and notified 2 users", callback.successMessage);
+        }
+    }
+
+    @Test
+    public void testNotifyEventCancellation_NoReservations() {
+        try (MockedStatic<FirebaseFirestore> firestoreStatic = mockStatic(FirebaseFirestore.class)) {
+            firestoreStatic.when(FirebaseFirestore::getInstance).thenReturn(mockFirestore);
+
+            when(mockFirestore.collection("reservations")).thenReturn(mockReservationsCollection);
+            when(mockFirestore.collection("notifications")).thenReturn(mockNotificationsCollection);
+
+            when(mockReservationsCollection.whereEqualTo("eventId", "event123"))
+                    .thenReturn(mockQueryAfterEventId);
+
+            when(mockQueryAfterEventId.whereEqualTo("status", "Active"))
+                    .thenReturn(mockQueryAfterStatus);
+
+            when(mockQueryAfterStatus.get()).thenReturn(mockTask);
+
+            when(mockQuerySnapshot.getDocuments()).thenReturn(Collections.emptyList());
+
+            when(mockTask.addOnSuccessListener(any())).thenAnswer(invocation -> {
+                OnSuccessListener<QuerySnapshot> listener = invocation.getArgument(0);
+                listener.onSuccess(mockQuerySnapshot);
+                return mockTask;
+            });
+
+            when(mockTask.addOnFailureListener(any())).thenReturn(mockTask);
+
+            NotificationService service = new NotificationService(mockContext);
+
+            TestCallback callback = new TestCallback();
+
+            service.notifyEventCancellation("event123", "Test Event", callback);
+
+            verify(mockNotificationsCollection, never()).add(any());
+
+            assertTrue(callback.successCalled);
+            assertFalse(callback.failureCalled);
+            assertEquals("Cancelled event and notified 0 users", callback.successMessage);
+        }
+    }
+
+    @Test
+    public void testNotifyEventCancellation_Failure() {
+        try (MockedStatic<FirebaseFirestore> firestoreStatic = mockStatic(FirebaseFirestore.class)) {
+            firestoreStatic.when(FirebaseFirestore::getInstance).thenReturn(mockFirestore);
+
+            when(mockFirestore.collection("reservations")).thenReturn(mockReservationsCollection);
+
+            when(mockReservationsCollection.whereEqualTo("eventId", "event123"))
+                    .thenReturn(mockQueryAfterEventId);
+
+            when(mockQueryAfterEventId.whereEqualTo("status", "Active"))
+                    .thenReturn(mockQueryAfterStatus);
+
+            when(mockQueryAfterStatus.get()).thenReturn(mockTask);
+
+            RuntimeException exception = new RuntimeException("Permission denied");
+
+            when(mockTask.addOnSuccessListener(any())).thenReturn(mockTask);
+
+            when(mockTask.addOnFailureListener(any())).thenAnswer(invocation -> {
+                OnFailureListener listener = invocation.getArgument(0);
+                listener.onFailure(exception);
+                return mockTask;
+            });
+
+            NotificationService service = new NotificationService(mockContext);
+
+            TestCallback callback = new TestCallback();
+
+            service.notifyEventCancellation("event123", "Test Event", callback);
+
+            assertFalse(callback.successCalled);
+            assertTrue(callback.failureCalled);
+            assertEquals("Failed to notify users: Permission denied", callback.failureMessage);
+
+            verify(mockFirestore, never()).collection("notifications");
+        }
+    }
+
+    private static class TestCallback implements NotificationService.NotificationCallback {
+        boolean successCalled = false;
+        boolean failureCalled = false;
+        String successMessage;
+        String failureMessage;
+
+        @Override
+        public void onSuccess(String message) {
+            successCalled = true;
+            successMessage = message;
+        }
+
+        @Override
+        public void onFailure(String error) {
+            failureCalled = true;
+            failureMessage = error;
+        }
+    }
+}

--- a/app/src/test/java/com/example/cloudticketreservationwk/service/NotificationServiceTest.java
+++ b/app/src/test/java/com/example/cloudticketreservationwk/service/NotificationServiceTest.java
@@ -2,7 +2,6 @@ package com.example.cloudticketreservationwk.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import android.content.Context;
@@ -16,6 +15,7 @@ import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.QuerySnapshot;
+import com.google.firebase.firestore.WriteBatch;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,8 +38,13 @@ public class NotificationServiceTest {
     private DocumentSnapshot mockDoc2;
     private DocumentReference mockDocRef1;
     private DocumentReference mockDocRef2;
-    private DocumentReference mockNotificationDocRef;
-    private Task<DocumentReference> mockAddTask;
+
+    private DocumentReference mockNotifDoc1;
+    private DocumentReference mockNotifDoc2;
+    private Task<Void> mockSetTask;
+
+    private WriteBatch mockBatch;
+    private Task<Void> mockCommitTask;
 
     @BeforeEach
     public void setUp() {
@@ -55,8 +60,13 @@ public class NotificationServiceTest {
         mockDoc2 = mock(DocumentSnapshot.class);
         mockDocRef1 = mock(DocumentReference.class);
         mockDocRef2 = mock(DocumentReference.class);
-        mockNotificationDocRef = mock(DocumentReference.class);
-        mockAddTask = mock(Task.class);
+
+        mockNotifDoc1 = mock(DocumentReference.class);
+        mockNotifDoc2 = mock(DocumentReference.class);
+        mockSetTask = mock(Task.class);
+
+        mockBatch = mock(WriteBatch.class);
+        mockCommitTask = mock(Task.class);
     }
 
     @Test
@@ -66,13 +76,12 @@ public class NotificationServiceTest {
 
             when(mockFirestore.collection("reservations")).thenReturn(mockReservationsCollection);
             when(mockFirestore.collection("notifications")).thenReturn(mockNotificationsCollection);
+            when(mockFirestore.batch()).thenReturn(mockBatch);
 
             when(mockReservationsCollection.whereEqualTo("eventId", "event123"))
                     .thenReturn(mockQueryAfterEventId);
-
             when(mockQueryAfterEventId.whereEqualTo("status", "Active"))
                     .thenReturn(mockQueryAfterStatus);
-
             when(mockQueryAfterStatus.get()).thenReturn(mockTask);
 
             when(mockDoc1.getString("userId")).thenReturn("user1");
@@ -85,18 +94,32 @@ public class NotificationServiceTest {
 
             when(mockQuerySnapshot.getDocuments()).thenReturn(Arrays.asList(mockDoc1, mockDoc2));
 
-            when(mockNotificationsCollection.add(any())).thenReturn(mockAddTask);
+            when(mockNotificationsCollection.document())
+                    .thenReturn(mockNotifDoc1)
+                    .thenReturn(mockNotifDoc2);
+
+            when(mockNotifDoc1.set(any())).thenReturn(mockSetTask);
+            when(mockNotifDoc2.set(any())).thenReturn(mockSetTask);
+
+            when(mockBatch.update(any(DocumentReference.class), any(String.class), any()))
+                    .thenReturn(mockBatch);
+            when(mockBatch.commit()).thenReturn(mockCommitTask);
 
             when(mockTask.addOnSuccessListener(any())).thenAnswer(invocation -> {
                 OnSuccessListener<QuerySnapshot> listener = invocation.getArgument(0);
                 listener.onSuccess(mockQuerySnapshot);
                 return mockTask;
             });
-
             when(mockTask.addOnFailureListener(any())).thenReturn(mockTask);
 
-            NotificationService service = new NotificationService(mockContext);
+            when(mockCommitTask.addOnSuccessListener(any())).thenAnswer(invocation -> {
+                OnSuccessListener<Void> listener = invocation.getArgument(0);
+                listener.onSuccess(null);
+                return mockCommitTask;
+            });
+            when(mockCommitTask.addOnFailureListener(any())).thenReturn(mockCommitTask);
 
+            NotificationService service = new NotificationService(mockContext);
             TestCallback callback = new TestCallback();
 
             service.notifyEventCancellation("event123", "Test Event", callback);
@@ -106,13 +129,15 @@ public class NotificationServiceTest {
             verify(mockQueryAfterEventId).whereEqualTo("status", "Active");
             verify(mockQueryAfterStatus).get();
 
-            verify(mockNotificationsCollection, times(2)).add(any());
-            verify(mockDocRef1).update("status", "Cancelled");
-            verify(mockDocRef2).update("status", "Cancelled");
+            verify(mockNotificationsCollection, times(2)).document();
+
+            verify(mockBatch).update(mockDocRef1, "status", "Cancelled");
+            verify(mockBatch).update(mockDocRef2, "status", "Cancelled");
+            verify(mockBatch).commit();
 
             assertTrue(callback.successCalled);
             assertFalse(callback.failureCalled);
-            assertEquals("Cancelled event and notified 2 users", callback.successMessage);
+            assertEquals("Cancelled 2 reservations and notified users", callback.successMessage);
         }
     }
 
@@ -123,36 +148,44 @@ public class NotificationServiceTest {
 
             when(mockFirestore.collection("reservations")).thenReturn(mockReservationsCollection);
             when(mockFirestore.collection("notifications")).thenReturn(mockNotificationsCollection);
+            when(mockFirestore.batch()).thenReturn(mockBatch);
 
             when(mockReservationsCollection.whereEqualTo("eventId", "event123"))
                     .thenReturn(mockQueryAfterEventId);
-
             when(mockQueryAfterEventId.whereEqualTo("status", "Active"))
                     .thenReturn(mockQueryAfterStatus);
-
             when(mockQueryAfterStatus.get()).thenReturn(mockTask);
 
             when(mockQuerySnapshot.getDocuments()).thenReturn(Collections.emptyList());
+
+            when(mockBatch.commit()).thenReturn(mockCommitTask);
 
             when(mockTask.addOnSuccessListener(any())).thenAnswer(invocation -> {
                 OnSuccessListener<QuerySnapshot> listener = invocation.getArgument(0);
                 listener.onSuccess(mockQuerySnapshot);
                 return mockTask;
             });
-
             when(mockTask.addOnFailureListener(any())).thenReturn(mockTask);
 
-            NotificationService service = new NotificationService(mockContext);
+            when(mockCommitTask.addOnSuccessListener(any())).thenAnswer(invocation -> {
+                OnSuccessListener<Void> listener = invocation.getArgument(0);
+                listener.onSuccess(null);
+                return mockCommitTask;
+            });
+            when(mockCommitTask.addOnFailureListener(any())).thenReturn(mockCommitTask);
 
+            NotificationService service = new NotificationService(mockContext);
             TestCallback callback = new TestCallback();
 
             service.notifyEventCancellation("event123", "Test Event", callback);
 
-            verify(mockNotificationsCollection, never()).add(any());
+            verify(mockNotificationsCollection, never()).document();
+            verify(mockBatch, never()).update(any(DocumentReference.class), any(String.class), any());
+            verify(mockBatch).commit();
 
             assertTrue(callback.successCalled);
             assertFalse(callback.failureCalled);
-            assertEquals("Cancelled event and notified 0 users", callback.successMessage);
+            assertEquals("Cancelled 0 reservations and notified users", callback.successMessage);
         }
     }
 
@@ -165,16 +198,13 @@ public class NotificationServiceTest {
 
             when(mockReservationsCollection.whereEqualTo("eventId", "event123"))
                     .thenReturn(mockQueryAfterEventId);
-
             when(mockQueryAfterEventId.whereEqualTo("status", "Active"))
                     .thenReturn(mockQueryAfterStatus);
-
             when(mockQueryAfterStatus.get()).thenReturn(mockTask);
 
             RuntimeException exception = new RuntimeException("Permission denied");
 
             when(mockTask.addOnSuccessListener(any())).thenReturn(mockTask);
-
             when(mockTask.addOnFailureListener(any())).thenAnswer(invocation -> {
                 OnFailureListener listener = invocation.getArgument(0);
                 listener.onFailure(exception);
@@ -182,14 +212,13 @@ public class NotificationServiceTest {
             });
 
             NotificationService service = new NotificationService(mockContext);
-
             TestCallback callback = new TestCallback();
 
             service.notifyEventCancellation("event123", "Test Event", callback);
 
             assertFalse(callback.successCalled);
             assertTrue(callback.failureCalled);
-            assertEquals("Failed to notify users: Permission denied", callback.failureMessage);
+            assertEquals("Failed to fetch reservations: Permission denied", callback.failureMessage);
 
             verify(mockFirestore, never()).collection("notifications");
         }


### PR DESCRIPTION
This PR introduces unit tests for the notifications implemented in `NotificationService`.

The tests validate the behavior of event cancellation notifications:
- querying reservations linked to a cancelled event
- updating reservation status from active to cancelled
- creating notifications for the affected users
- handling success and failure scenarios from Firestore operations

Mockito was used to mock Firebase Firestore interactions

The `NotificationServiceTest.java` file was added under `test/com/example/cloudticketreservationwk/service`