### PR TITLE
Bug/event edit

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -9,9 +9,13 @@
     <option name="autoReloadType" value="NONE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="3fdad77f-c22d-44a4-813d-b11bd1679aca" name="Changes" comment="Merge remote-tracking branch 'origin/dev' into feature/events&#10;# Please enter a commit message to explain why this merge is necessary,&#10;# especially if it merges an updated upstream into a topic branch.&#10;#&#10;# Lines starting with '#' will be ignored, and an empty message aborts&#10;# the commit.">
+    <list default="true" id="3fdad77f-c22d-44a4-813d-b11bd1679aca" name="Changes" comment="Modify admin capacity edit as to not override active reservations">
+      <change afterPath="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk/controller/AdminEventValidationTest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk/integration/AdminEventIntegrationTest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk/service/EventCapacityUpdateTest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk/service/EventServiceTest.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/src/main/java/com/example/cloudticketreservationwk/controller/AdminEventFormActivity.java" beforeDir="false" afterPath="$PROJECT_DIR$/app/src/main/java/com/example/cloudticketreservationwk/controller/AdminEventFormActivity.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/app/build.gradle.kts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -85,6 +89,10 @@
   <component name="PropertiesComponent"><![CDATA[{
   "keyToString": {
     "Android App.app.executor": "Run",
+    "Gradle.AdminEventValidationTest.executor": "Run",
+    "Gradle.AdminEventValidationTest.testEmptyTitleIsInvalid.executor": "Run",
+    "Gradle.AdminEventValidationTest.testValidCapacityValues.executor": "Run",
+    "Gradle.EventCapacityUpdateTest.executor": "Run",
     "ModuleVcsDetector.initialDetectionPerformed": "true",
     "RunOnceActivity.MCP Project settings loaded": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
@@ -114,7 +122,7 @@
       <recent name="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk" />
     </key>
   </component>
-  <component name="RunManager">
+  <component name="RunManager" selected="Gradle.EventCapacityUpdateTest">
     <configuration name="app" type="AndroidRunConfigurationType" factoryName="Android App" activateToolWindowBeforeRun="false">
       <module name="CloudTicketReservationWK.app" />
       <option name="ANDROID_RUN_CONFIGURATION_SCHEMA_VERSION" value="1" />
@@ -187,6 +195,110 @@
         <option name="Android.Gradle.BeforeRunTask" enabled="true" />
       </method>
     </configuration>
+    <configuration name="AdminEventValidationTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":app:testDebugUnitTest" />
+            <option value="--tests" />
+            <option value="&quot;com.example.cloudticketreservationwk.controller.AdminEventValidationTest&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
+    <configuration name="AdminEventValidationTest.testEmptyTitleIsInvalid" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":app:testDebugUnitTest" />
+            <option value="--tests" />
+            <option value="&quot;com.example.cloudticketreservationwk.controller.AdminEventValidationTest.testEmptyTitleIsInvalid&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
+    <configuration name="AdminEventValidationTest.testValidCapacityValues" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":app:testDebugUnitTest" />
+            <option value="--tests" />
+            <option value="&quot;com.example.cloudticketreservationwk.controller.AdminEventValidationTest.testValidCapacityValues&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
+    <configuration name="EventCapacityUpdateTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":app:testDebugUnitTest" />
+            <option value="--tests" />
+            <option value="&quot;com.example.cloudticketreservationwk.service.EventCapacityUpdateTest&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
+    <recent_temporary>
+      <list>
+        <item itemvalue="Gradle.EventCapacityUpdateTest" />
+        <item itemvalue="Gradle.AdminEventValidationTest.testValidCapacityValues" />
+        <item itemvalue="Gradle.AdminEventValidationTest.testEmptyTitleIsInvalid" />
+        <item itemvalue="Gradle.AdminEventValidationTest" />
+      </list>
+    </recent_temporary>
   </component>
   <component name="SharedIndexes">
     <attachedChunks>
@@ -283,7 +395,15 @@
       <option name="project" value="LOCAL" />
       <updated>1773427306364</updated>
     </task>
-    <option name="localTasksCounter" value="11" />
+    <task id="LOCAL-00011" summary="Modify admin capacity edit as to not override active reservations">
+      <option name="closed" value="true" />
+      <created>1775339556655</created>
+      <option name="number" value="00011" />
+      <option name="presentableId" value="LOCAL-00011" />
+      <option name="project" value="LOCAL" />
+      <updated>1775339556655</updated>
+    </task>
+    <option name="localTasksCounter" value="12" />
     <servers />
   </component>
   <component name="VcsManagerConfiguration">
@@ -294,7 +414,8 @@
     <MESSAGE value="Modify to JUnit 4." />
     <MESSAGE value="Update example test file to JUnit 4." />
     <MESSAGE value="Commit" />
-    <option name="LAST_COMMIT_MESSAGE" value="Commit" />
+    <MESSAGE value="Modify admin capacity edit as to not override active reservations" />
+    <option name="LAST_COMMIT_MESSAGE" value="Modify admin capacity edit as to not override active reservations" />
   </component>
   <component name="play_dynamic_filters_status">
     <option name="appIdToCheckInfo">

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -11,10 +11,7 @@
   <component name="ChangeListManager">
     <list default="true" id="3fdad77f-c22d-44a4-813d-b11bd1679aca" name="Changes" comment="Merge remote-tracking branch 'origin/dev' into feature/events&#10;# Please enter a commit message to explain why this merge is necessary,&#10;# especially if it merges an updated upstream into a topic branch.&#10;#&#10;# Lines starting with '#' will be ignored, and an empty message aborts&#10;# the commit.">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/src/main/java/com/example/cloudticketreservationwk/controller/MyReservationsActivity.java" beforeDir="false" afterPath="$PROJECT_DIR$/app/src/main/java/com/example/cloudticketreservationwk/controller/MyReservationsActivity.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/src/main/java/com/example/cloudticketreservationwk/controller/ReservationAdapter.java" beforeDir="false" afterPath="$PROJECT_DIR$/app/src/main/java/com/example/cloudticketreservationwk/controller/ReservationAdapter.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/src/main/java/com/example/cloudticketreservationwk/service/NotificationService.java" beforeDir="false" afterPath="$PROJECT_DIR$/app/src/main/java/com/example/cloudticketreservationwk/service/NotificationService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/src/main/java/com/example/cloudticketreservationwk/service/ReservationService.java" beforeDir="false" afterPath="$PROJECT_DIR$/app/src/main/java/com/example/cloudticketreservationwk/service/ReservationService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/src/main/java/com/example/cloudticketreservationwk/controller/AdminEventFormActivity.java" beforeDir="false" afterPath="$PROJECT_DIR$/app/src/main/java/com/example/cloudticketreservationwk/controller/AdminEventFormActivity.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -24,7 +21,7 @@
   <component name="ClangdSettings">
     <option name="formatViaClangd" value="false" />
   </component>
-  <component name="ExecutionTargetManager" SELECTED_TARGET="device_and_snapshot_combo_box_target[PhysicalDevice::serial=R5CWA1BZZSE]" />
+  <component name="ExecutionTargetManager" SELECTED_TARGET="device_and_snapshot_combo_box_target[LocalEmulator::path=/Users/elif/.android/avd/Medium_Phone.avd]" />
   <component name="ExternalProjectsData">
     <projectState path="$PROJECT_DIR$">
       <ProjectState />
@@ -33,14 +30,12 @@
   <component name="ExternalProjectsManager">
     <system id="GRADLE">
       <state>
+        <task path="$PROJECT_DIR$">
+          <activation />
+        </task>
         <projects_view>
           <tree_state>
-            <expand>
-              <path>
-                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
-                <item name="CloudTicketReservationWK" type="f1a62948:ProjectNode" />
-              </path>
-            </expand>
+            <expand />
             <select />
           </tree_state>
         </projects_view>
@@ -101,7 +96,7 @@
     "cf.first.check.clang-format": "false",
     "cidr.known.project.marker": "true",
     "com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultModelSelectionForGA.v1": "true",
-    "git-widget-placeholder": "dev",
+    "git-widget-placeholder": "bug/event-edit",
     "ignore.virus.scanning.warn.message": "true",
     "junie.onboarding.icon.badge.shown": "true",
     "kotlin-language-version-configured": "true",

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,4 +59,5 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:33.1.2"))
     implementation("com.google.firebase:firebase-auth")
     implementation("com.google.firebase:firebase-firestore")
+
 }

--- a/app/src/main/java/com/example/cloudticketreservationwk/controller/AdminEventFormActivity.java
+++ b/app/src/main/java/com/example/cloudticketreservationwk/controller/AdminEventFormActivity.java
@@ -221,12 +221,26 @@ public class AdminEventFormActivity extends AppCompatActivity {
         int reservedSeats = oldTotalSeats - oldAvailableSeats;
         int newAvailableSeats = newTotalSeats - reservedSeats;
 
-        // If new capacity is less than existing reservations, we set available to 0
-        // (This prevents negative available seats but shows "Full")
-        if (newAvailableSeats < 0) newAvailableSeats = 0;
+        if (newTotalSeats < reservedSeats) {
+            new MaterialAlertDialogBuilder(this)
+                    .setTitle("Cannot Reduce Capacity")
+                    .setMessage(String.format(
+                            "Cannot reduce capacity to %d because there are %d existing reservations.\n\n" +
+                                    "Please increase capacity or cancel entire event.",
+                            newTotalSeats, reservedSeats))
+                    .setPositiveButton("OK", null)
+                    .show();
+            return;
+        }
+
+        newAvailableSeats = newTotalSeats - reservedSeats;
 
         Event event = new Event(title, date, location, category, newAvailableSeats, newTotalSeats);
         event.setId(eventId);
+
+        // Preserve cancel
+        boolean isCancelled = getIntent().getBooleanExtra("IS_CANCELLED", false);
+        event.setCancelled(isCancelled);
 
         eventService.editEvent(event, new EventService.EventCallback() {
             @Override

--- a/app/src/test/java/com/example/cloudticketreservationwk/controller/AdminEventValidationTest.java
+++ b/app/src/test/java/com/example/cloudticketreservationwk/controller/AdminEventValidationTest.java
@@ -1,0 +1,192 @@
+package com.example.cloudticketreservationwk.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class AdminEventValidationTest {
+    private AdminEventValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new AdminEventValidator();
+    }
+
+    @Test
+    void testValidEventPassesValidation() {
+        ValidationResult result = validator.validate(
+                "Valid Event Title",
+                "2026-05-15",
+                "Valid Location",
+                "Music",
+                100
+        );
+
+        assertTrue(result.isValid());
+        assertNull(result.getErrorMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "   "})
+    void testEmptyTitleIsInvalid(String invalidTitle) {
+        ValidationResult result = validator.validate(
+                invalidTitle,
+                "2026-05-15",
+                "Location",
+                "Category",
+                100
+        );
+
+        assertFalse(result.isValid());
+        assertEquals("Title is required", result.getErrorMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "   "})
+    void testEmptyDateIsInvalid(String invalidDate) {
+        ValidationResult result = validator.validate(
+                "Valid Title",
+                invalidDate,
+                "Location",
+                "Category",
+                100
+        );
+
+        assertFalse(result.isValid());
+        assertEquals("Date is required", result.getErrorMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "   "})
+    void testEmptyLocationIsInvalid(String invalidLocation) {
+        ValidationResult result = validator.validate(
+                "Valid Title",
+                "2026-05-15",
+                invalidLocation,
+                "Category",
+                100
+        );
+
+        assertFalse(result.isValid());
+        assertEquals("Location is required", result.getErrorMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "   "})
+    void testEmptyCategoryIsInvalid(String invalidCategory) {
+        ValidationResult result = validator.validate(
+                "Valid Title",
+                "2026-05-15",
+                "Location",
+                invalidCategory,
+                100
+        );
+
+        assertFalse(result.isValid());
+        assertEquals("Category is required", result.getErrorMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0", "-1", "-5", "abc", "12.5"})
+    void testInvalidCapacityValues(String invalidCapacity) {
+        int capacity;
+        try {
+            capacity = Integer.parseInt(invalidCapacity);
+        } catch (NumberFormatException e) {
+            // Capacity is empty or invalid number
+            assertTrue(true);
+            return;
+        }
+
+        ValidationResult result = validator.validate(
+                "Valid Title",
+                "2026-05-15",
+                "Location",
+                "Category",
+                capacity
+        );
+
+        assertFalse(result.isValid());
+        assertTrue(result.getErrorMessage().contains("Capacity"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 10, 50, 100, 1000})
+    void testValidCapacityValues(int validCapacity) {
+        ValidationResult result = validator.validate(
+                "Valid Title",
+                "2026-05-15",
+                "Location",
+                "Category",
+                validCapacity
+        );
+
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void testEmptyCapacityShowsError() {
+        // Simulating empty capacity field
+        ValidationResult result = validator.validate(
+                "Valid Title",
+                "2026-05-15",
+                "Location",
+                "Category",
+                0  // 0 capacity should be invalid
+        );
+
+        assertFalse(result.isValid());
+        assertEquals("Capacity must be greater than 0", result.getErrorMessage());
+    }
+
+    // Helper class to encapsulate validation logic from AdminEventFormActivity
+    static class AdminEventValidator {
+        ValidationResult validate(String title, String date, String location,
+                                  String category, int capacity) {
+            if (title == null || title.trim().isEmpty()) {
+                return new ValidationResult(false, "Title is required");
+            }
+            if (date == null || date.trim().isEmpty()) {
+                return new ValidationResult(false, "Date is required");
+            }
+            if (location == null || location.trim().isEmpty()) {
+                return new ValidationResult(false, "Location is required");
+            }
+            if (category == null || category.trim().isEmpty()) {
+                return new ValidationResult(false, "Category is required");
+            }
+            if (capacity <= 0) {
+                return new ValidationResult(false, "Capacity must be greater than 0");
+            }
+
+            return new ValidationResult(true, null);
+        }
+    }
+
+    static class ValidationResult {
+        private final boolean valid;
+        private final String errorMessage;
+
+        ValidationResult(boolean valid, String errorMessage) {
+            this.valid = valid;
+            this.errorMessage = errorMessage;
+        }
+
+        boolean isValid() { return valid; }
+        String getErrorMessage() { return errorMessage; }
+    }
+
+}

--- a/app/src/test/java/com/example/cloudticketreservationwk/service/EventCapacityUpdateTest.java
+++ b/app/src/test/java/com/example/cloudticketreservationwk/service/EventCapacityUpdateTest.java
@@ -1,0 +1,147 @@
+package com.example.cloudticketreservationwk.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EventCapacityUpdateTest {
+    @Test
+    @DisplayName("Prevent reducing capacity below existing reservations")
+    void testCapacityReduction_BelowReservations_ShouldBeBlocked() {
+        int oldTotalSeats = 100;
+        int oldAvailableSeats = 20;
+        int reservedSeats = oldTotalSeats - oldAvailableSeats; // = 80
+
+        // Admin tries to reduce capacity to 50 (< 80 reserved)
+        int requestedNewTotalSeats = 50;
+
+        // Operation should be REJECTED
+        boolean isValidReduction = requestedNewTotalSeats >= reservedSeats;
+        assertFalse(isValidReduction, "Should not allow capacity below reserved seats");
+
+        // Event should remain unchanged
+        int finalTotalSeats = oldTotalSeats;
+        int finalAvailableSeats = oldAvailableSeats;
+
+        assertEquals(100, finalTotalSeats);
+        assertEquals(20, finalAvailableSeats);
+        assertEquals(80, reservedSeats);
+    }
+
+    @Test
+    @DisplayName("Allow reducing capacity when still above reservations")
+    void testCapacityReduction_AboveReservations_ShouldBeAllowed() {
+        int oldTotalSeats = 100;
+        int oldAvailableSeats = 20;
+        int reservedSeats = oldTotalSeats - oldAvailableSeats; // = 80
+
+        // Admin reduces capacity to 90 (still >= 80 reserved)
+        int requestedNewTotalSeats = 90;
+
+        // Operation allowed
+        boolean isValidReduction = requestedNewTotalSeats >= reservedSeats;
+        assertTrue(isValidReduction, "Should allow reduction as long as capacity >= reserved seats");
+
+        int newAvailableSeats = requestedNewTotalSeats - reservedSeats; // 90 - 80 = 10
+
+        assertEquals(90, requestedNewTotalSeats);
+        assertEquals(10, newAvailableSeats);
+        assertEquals(80, reservedSeats); // Reservations unchanged
+    }
+
+    @Test
+    @DisplayName("Should ALLOW increasing capacity")
+    void testCapacityIncrease() {
+        int oldTotalSeats = 100;
+        int oldAvailableSeats = 20;
+        int reservedSeats = oldTotalSeats - oldAvailableSeats; // 80
+
+        // Admin increases capacity to 150
+        int newTotalSeats = 150;
+
+        // Operation allowed
+        assertTrue(newTotalSeats >= reservedSeats);
+
+        int newAvailableSeats = newTotalSeats - reservedSeats;
+        assertEquals(70, newAvailableSeats);
+        assertEquals(150, newTotalSeats);
+    }
+
+    @Test
+    @DisplayName("Should show error message when trying to reduce capacity below reservations")
+    void testCapacityReduction_ShowsErrorMessage() {
+        int totalSeats = 100;
+        int reservedSeats = 80;
+        int requestedCapacity = 50;
+
+        // Validation check
+        boolean wouldOverbook = requestedCapacity < reservedSeats;
+
+        // Show error
+        assertTrue(wouldOverbook);
+
+        // Expected error message
+        String expectedError = String.format(
+                "Cannot reduce capacity to %d because there are %d existing reservations.\n\n" +
+                        "Please increase capacity or cancel entire event.",
+                requestedCapacity, reservedSeats
+        );
+
+        assertTrue(expectedError.contains("Cannot reduce capacity"));
+        assertTrue(expectedError.contains(String.valueOf(requestedCapacity)));
+        assertTrue(expectedError.contains(String.valueOf(reservedSeats)));
+    }
+
+    @Test
+    @DisplayName("Should allow capacity to be set exactly equal to reservations")
+    void testCapacityReduction_ExactlyEqualReservations() {
+        int reservedSeats = 80;
+
+        // Admin sets capacity exactly to 80
+        int newTotalSeats = 80;
+
+        // Allowed
+        boolean isValidReduction = newTotalSeats >= reservedSeats;
+        assertTrue(isValidReduction);
+
+        int newAvailableSeats = newTotalSeats - reservedSeats; // 0
+        assertEquals(0, newAvailableSeats);
+    }
+
+    @Test
+    @DisplayName("Should validate capacity before attempting update")
+    void testCapacityValidation_BeforeUpdate() {
+        int reservedSeats = 75;
+
+        // Invalid scenarios
+        assertTrue(50 < reservedSeats);  // Overbook
+        assertTrue(74 < reservedSeats);  // Overbook by 1
+        assertTrue(0 < reservedSeats);   // Overbook significantly
+
+        // Valid scenarios (should be allowed)
+        assertTrue(75 == reservedSeats); // Exactly full
+        assertTrue(100 > reservedSeats); // Has available seats
+        assertTrue(1000 > reservedSeats); // Much larger
+    }
+
+    @Test
+    @DisplayName("Should preserve existing reservations when changing capacity")
+    void testPreserveReservations_WhenCapacityChanges() {
+        // Given
+        int originalReservations = 80;
+        int originalTotalSeats = 100;
+
+        // When: Capacity changes to 120
+        int newTotalSeats = 120;
+
+        // Then: Reservations remain at 80
+        int reservationsAfterChange = originalReservations;
+        assertEquals(80, reservationsAfterChange);
+
+        // Available seats recalculated
+        int newAvailableSeats = newTotalSeats - reservationsAfterChange;
+        assertEquals(40, newAvailableSeats);
+
+    }
+}

--- a/app/src/test/java/com/example/cloudticketreservationwk/service/EventServiceTest.java
+++ b/app/src/test/java/com/example/cloudticketreservationwk/service/EventServiceTest.java
@@ -1,0 +1,140 @@
+package com.example.cloudticketreservationwk.service;
+import com.example.cloudticketreservationwk.model.Event;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mock;
+
+@DisplayName("Event Service Tests")
+public class EventServiceTest {
+
+    @Mock
+    private FirebaseFirestore mockFirestore;
+    @Mock
+    private CollectionReference mockEventsCollection;
+    @Mock
+    private DocumentReference mockDocumentReference;
+    private EventService eventService;
+    private Event testEvent;
+
+    @BeforeEach
+    void setup() {
+        testEvent = new Event(
+                "Test Concert",
+                "2026-05-15",
+                "Bell Center",
+                "Music",
+                100,
+                100
+        );
+        testEvent.setId("test-event-1");
+    }
+
+    @Test
+    @DisplayName("Should validate event before adding")
+    void testAddEventValidData() {
+        // Test the event creation logic before Firebase call
+        assertNotNull(testEvent);
+        assertNotNull(testEvent.getTitle());
+        assertNotNull(testEvent.getDate());
+        assertNotNull(testEvent.getLocation());
+        assertNotNull(testEvent.getCategory());
+        assertTrue(testEvent.getTotalSeats() > 0);
+
+        // Verify event has no ID before adding
+        assertNull(testEvent.getId());
+
+        // Simulate ID assignment (what Firestore would do)
+        String mockFirestoreId = "firestore-generated-id-456";
+        testEvent.setId(mockFirestoreId);
+
+        // Verify ID was set
+        assertNotNull(testEvent.getId());
+        assertEquals(mockFirestoreId, testEvent.getId());
+    }
+
+    @Test
+    @DisplayName("Should update event fields correctly")
+    void testEventUpdate() {
+        // Update fields
+        testEvent.setTitle("New Title");
+        testEvent.setDate("2026-06-01");
+        testEvent.setLocation("New Location");
+        testEvent.setCategory("Rock");
+        testEvent.setTotalSeats(200);
+        testEvent.setAvailableSeats(150);
+        testEvent.setCancelled(true);
+
+        assertEquals("New Title", testEvent.getTitle());
+        assertEquals("2026-06-01", testEvent.getDate());
+        assertEquals("New Location", testEvent.getLocation());
+        assertEquals("Rock", testEvent.getCategory());
+        assertEquals(200, testEvent.getTotalSeats());
+        assertEquals(150, testEvent.getAvailableSeats());
+        assertTrue(testEvent.getIsCancelled());
+    }
+    @Test
+    @DisplayName("Should calculate available seats after capacity change")
+    void testAvailableSeatsCalculation() {
+        int oldTotalSeats = 100;
+        int oldAvailableSeats = 20;
+        int reservedSeats = oldTotalSeats - oldAvailableSeats; // 80 booked
+
+        // Admin increases capacity to 150
+        int newTotalSeats = 150;
+        int newAvailableSeats = newTotalSeats - reservedSeats;
+        assertEquals(70, newAvailableSeats);
+
+        // Admin decreases capacity to 90
+        newTotalSeats = 90;
+        newAvailableSeats = newTotalSeats - reservedSeats;
+        assertEquals(10, newAvailableSeats);
+
+        // Admin decreases capacity below reservations (your current logic)
+        newTotalSeats = 50;
+        newAvailableSeats = newTotalSeats - reservedSeats;
+        if (newAvailableSeats < 0) newAvailableSeats = 0; // Your logic
+        assertEquals(0, newAvailableSeats);
+    }
+
+    @Test
+    @DisplayName("Should create sample events for seeding")
+    void testSampleEvents() {
+        // Actual sample events from seedInitialEvents
+        Event comedyNight = new Event("Comedy Night", "2026-03-10", "Downtown", "Comedy", 100, 100);
+        Event techMeetup = new Event("Tech Meetup", "2026-03-12", "Campus Hall", "Tech", 50, 50);
+        Event liveConcert = new Event("Live Concert", "2026-03-20", "Main Arena", "Music", 500, 500);
+        Event foodFestival = new Event("Food Festival", "2026-03-25", "Old Port", "Food", 200, 200);
+
+        // Verify comedy night
+        assertEquals("Comedy Night", comedyNight.getTitle());
+        assertEquals("2026-03-10", comedyNight.getDate());
+        assertEquals("Downtown", comedyNight.getLocation());
+        assertEquals("Comedy", comedyNight.getCategory());
+        assertEquals(100, comedyNight.getTotalSeats());
+
+        // Verify tech meetup
+        assertEquals("Tech Meetup", techMeetup.getTitle());
+        assertEquals(50, techMeetup.getTotalSeats());
+
+        // Verify live concert
+        assertEquals("Live Concert", liveConcert.getTitle());
+        assertEquals(500, liveConcert.getTotalSeats());
+
+        // Verify food festival
+        assertEquals("Food Festival", foodFestival.getTitle());
+        assertEquals(200, foodFestival.getTotalSeats());
+    }
+
+
+    }


### PR DESCRIPTION
This PR fixes #45, changes event capacity modification logic and creates admin action tests. New capacity logic: allow any increase in capacity, but only allow decrease in capacity if the new capacity is greater than the number of existing reservations. Or else an error message appears (see below) and the capacity is set to the original capacity (no modification). 
<img width="586" height="424" alt="image" src="https://github.com/user-attachments/assets/82d2b7cd-2eba-4f3f-90d9-755bcadace2d" />
