### PR TITLE
Added e2e tests for T4 and T5

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -10,12 +10,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="3fdad77f-c22d-44a4-813d-b11bd1679aca" name="Changes" comment="Modify admin capacity edit as to not override active reservations">
-      <change afterPath="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk/controller/AdminEventValidationTest.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk/integration/AdminEventIntegrationTest.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk/service/EventCapacityUpdateTest.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk/service/EventServiceTest.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/app/build.gradle.kts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -25,7 +20,7 @@
   <component name="ClangdSettings">
     <option name="formatViaClangd" value="false" />
   </component>
-  <component name="ExecutionTargetManager" SELECTED_TARGET="device_and_snapshot_combo_box_target[LocalEmulator::path=/Users/elif/.android/avd/Medium_Phone.avd]" />
+  <component name="ExecutionTargetManager" SELECTED_TARGET="device_and_snapshot_combo_box_target[PhysicalDevice::serial=R5CWA1BZZSE]" />
   <component name="ExternalProjectsData">
     <projectState path="$PROJECT_DIR$">
       <ProjectState />
@@ -39,7 +34,12 @@
         </task>
         <projects_view>
           <tree_state>
-            <expand />
+            <expand>
+              <path>
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
+                <item name="CloudTicketReservationWK" type="f1a62948:ProjectNode" />
+              </path>
+            </expand>
             <select />
           </tree_state>
         </projects_view>
@@ -73,7 +73,7 @@
     &quot;accountId&quot;: &quot;d9082485-d84a-41e9-8978-834d7221064d&quot;
   }
 }</component>
-  <component name="GradleScriptDefinitionsStorage" workingDir="$PROJECT_DIR$" gradleHome="$USER_HOME$/.gradle/wrapper/dists/gradle-8.11.1-bin/bpt9gzteqjrbo1mjrsomdt32c/gradle-8.11.1" javaHome="$APPLICATION_HOME_DIR$/jbr/Contents/Home" gradleVersion="8.11.1" />
+  <component name="GradleScriptDefinitionsStorage" workingDir="$PROJECT_DIR$" gradleHome="C:\Users\hibat_jze8h9z\.gradle\wrapper\dists\gradle-8.11.1-bin\bpt9gzteqjrbo1mjrsomdt32c\gradle-8.11.1" javaHome="C:\Program Files\Android\Android Studio\jbr" gradleVersion="8.11.1" />
   <component name="McpProjectServerCommands">
     <commands />
     <urls />
@@ -104,7 +104,7 @@
     "cf.first.check.clang-format": "false",
     "cidr.known.project.marker": "true",
     "com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultModelSelectionForGA.v1": "true",
-    "git-widget-placeholder": "bug/event-edit",
+    "git-widget-placeholder": "e2e/hibat",
     "ignore.virus.scanning.warn.message": "true",
     "junie.onboarding.icon.badge.shown": "true",
     "kotlin-language-version-configured": "true",
@@ -122,7 +122,7 @@
       <recent name="$PROJECT_DIR$/app/src/test/java/com/example/cloudticketreservationwk" />
     </key>
   </component>
-  <component name="RunManager" selected="Gradle.EventCapacityUpdateTest">
+  <component name="RunManager" selected="Android App.app">
     <configuration name="app" type="AndroidRunConfigurationType" factoryName="Android App" activateToolWindowBeforeRun="false">
       <module name="CloudTicketReservationWK.app" />
       <option name="ANDROID_RUN_CONFIGURATION_SCHEMA_VERSION" value="1" />

--- a/e2e/admin_cancel_event_flow.yaml
+++ b/e2e/admin_cancel_event_flow.yaml
@@ -1,0 +1,98 @@
+appId: com.example.cloudticketreservationwk
+---
+- launchApp:
+    clearState: true
+
+# setup: ensure that the user has a reservation for the event that will be cancelled
+# can put this part as comments to ignore it
+# Customer login
+- tapOn:
+    id: "etEmail"
+- inputText: "05hiba.talbi50@gmail.com"
+
+- tapOn:
+    id: "etPassword"
+- inputText: "123456"
+
+- hideKeyboard
+- tapOn:
+    id: "btnSubmit"
+
+- scrollUntilVisible:
+    element: "Comedy Night"
+    direction: DOWN
+- tapOn: "Comedy Night"
+- tapOn:
+      id: "etTickets"
+- inputText: "1"
+- hideKeyboard
+- tapOn:
+      id: "btnReserve"
+- assertVisible: "Reservation Confirmed"
+# Logout
+- tapOn:
+    id: "btnLogout"
+- tapOn: "Logout"
+
+# step 1- admin cancels the event
+# Admin login
+- tapOn:
+    id: "etEmail"
+- inputText: "hiba.teatea@gmail.com"
+
+- tapOn:
+    id: "etPassword"
+- inputText: "123456"
+
+- hideKeyboard
+- tapOn:
+    id: "btnSubmit"
+
+# Open the event that should already have a reservation
+- scrollUntilVisible:
+    element: "Comedy Night"
+    direction: DOWN
+
+# Cancel event from admin dashboard card
+- tapOn:
+    text: "Cancel"
+    index: 0
+
+- tapOn: "Yes, Cancel Event"
+
+# Wait for Firestore/UI refresh
+- extendedWaitUntil:
+    visible: "STATUS: CANCELED"
+    timeout: 10000
+
+# Logout admin
+- tapOn:
+    id: "btnLogout"
+- tapOn: "Logout"
+
+# step2- the customer checks that the event was cancelled on their acc
+# Customer login
+- tapOn:
+    id: "etEmail"
+- inputText: "05hiba.talbi50@gmail.com"
+
+- tapOn:
+    id: "etPassword"
+- inputText: "123456"
+
+- hideKeyboard
+- tapOn:
+    id: "btnSubmit"
+
+# Open My Reservations
+- tapOn:
+    id: "btnMyReservations"
+
+# Verify related reservation is cancelled
+- scrollUntilVisible:
+    element: "Comedy Night"
+    direction: DOWN
+
+- assertVisible: "Comedy Night"
+- assertVisible: "Status: Cancelled"
+- assertVisible: "Cancelled"

--- a/e2e/customer_cancel_reservation_flow.yaml
+++ b/e2e/customer_cancel_reservation_flow.yaml
@@ -1,0 +1,90 @@
+appId: com.example.cloudticketreservationwk
+---
+- launchApp:
+    clearState: true
+
+# Customer login
+- tapOn:
+    id: "etEmail"
+- inputText: "cancelTest@gmail.com"
+- tapOn:
+    id: "etPassword"
+- inputText: "123456"
+- hideKeyboard
+- tapOn:
+    id: "btnSubmit"
+
+
+# setup: ensure the user has reservations to the event
+# can put this part in comments if its unecessary
+# Open event
+
+#- scrollUntilVisible:
+#    element: "Tech Meetup"
+#    direction: DOWN
+#- tapOn: "Tech Meetup"
+# Verify initial seat count
+# make sure the seat count is correct
+#- assertVisible: "Available seats: 386"
+# Create reservation
+#- tapOn:
+#    id: "etTickets"
+#- inputText: "2"
+#- hideKeyboard
+#- tapOn:
+#    id: "btnReserve"
+#- assertVisible: "Reservation Confirmed"
+
+# step 1- customer cancels reservation
+# Open My Reservations
+# if the setup was ran use this
+#- tapOn:
+#    id: "btnGoMyReservations"
+# else:
+- tapOn:
+    id: "btnMyReservations"
+
+# Find reservation
+- scrollUntilVisible:
+    element: "Tech Meetup"
+    direction: DOWN
+
+# Verify reservation is active
+- assertVisible: "Status: Active"
+
+# Cancel the reservation for Tech Meetup specifically
+- tapOn:
+    text: "Cancel"
+    below: "Tech Meetup"
+
+
+# Wait for update
+- extendedWaitUntil:
+    visible: "Status: Cancelled"
+    timeout: 10000
+- assertVisible: "Cancelled"
+
+# step 2- verify seats are restored
+# Go back to event list
+- tapOn:
+    id: "btnBackFromReservations"
+
+# check to ensure it does go back
+- extendedWaitUntil:
+    visible:
+      id: "btnMyReservations"
+    timeout: 10000
+
+# Open event again
+- scrollUntilVisible:
+    element: "Tech Meetup"
+    direction: DOWN
+
+- tapOn: "Tech Meetup"
+
+# Verify seat count restored
+- extendedWaitUntil:
+    visible: "Available seats: 386"
+    timeout: 10000
+
+- assertVisible: "Available seats: 386"

--- a/e2e/customer_cancel_reservation_flow.yaml
+++ b/e2e/customer_cancel_reservation_flow.yaml
@@ -66,6 +66,9 @@ appId: com.example.cloudticketreservationwk
 
 # step 2- verify seats are restored
 # Go back to event list
+- extendedWaitUntil:
+    notVisible: "Reservation Cancelled"
+    timeout: 10000
 - tapOn:
     id: "btnBackFromReservations"
 


### PR DESCRIPTION
This pr introduces two implemented maestro e2e tests that validate the following flows:

**Flow 1: T4-- Admin cancels event → related reservations are cancelled → users are notified**

https://github.com/user-attachments/assets/2a72ec80-9bd7-4ce4-b25c-c7372ae6cd67

**Test description:**
- Admin logs in
- Admin navigates to event "Comedy Night"
- Admin cancels event 
- Admin logs out 
- Customer logs in
- Customer goes to their "My Reservations" dashboard
- Customer sees that the event they reserved for was cancelled

Note: I added a setup part where it ensures that the user reserves tickets for that event first, to ensure that the test can run properly

This test was added to file: `e2e/admin_cancel_event_flow.yaml `


**Flow 2: T5-- Customer cancels reservation → seat count is restored**

https://github.com/user-attachments/assets/f460754e-db28-4123-8e71-dd87c5f493ac

**Test description:**
- Customer logs in
- Customer goes to their "My Reservations" dashboard
- Customer presses on "Cancel" button
- Customer goes back to the main page
- Customer verifies that the number of seats available went back to the original count before their reservation

The event "Tech Meetup" is used for this test

This test was added to the file: `e2e/customer_cancel_reservation_flow.yaml`

Note: I added a setup part where it ensures that the user already reserved tickets for that event first. And, the seat count is hard coded 

**How to run:**
maestro test e2e/admin_cancel_event_flow.yaml  
maestro test e2e/customer_cancel_reservation_flow.yaml